### PR TITLE
Fix join group link

### DIFF
--- a/index.md
+++ b/index.md
@@ -103,7 +103,7 @@ layout: default
 ## **Get Emails for Future Events**
 {:style="text-align: center;"}
 
-* Join our [Google Group](https://l.messenger.com/l.php?u=https%3A%2F%2Fgroups.google.com%2Fa%2Fvt.edu%2Fforum%2F%23!forum%2Fgho-events-g&h=ATOwyIjJb2e0l8lhcXzgxPjYQZgOQiEd5NxzdOkeDh9jI-VsaoeCJr0f6qEvzwuvXBdHO-IRnfde0q1Fotl-JUluWDtpz-zaHU70jZ1stlNOt6fE_m5NfWO4p02mjnbCPSl68V2yRvC7gQ) 
+* Join our [Google Group](https://groups.google.com/a/vt.edu/forum/#!forum/gho-events-g) 
 * Click "Join group post" at the top
 {:style="width: 70%; margin-left: 15%; font-size: 120%; margin-bottom: 4rem;"}
 ---


### PR DESCRIPTION
The former link is from l.messenger.com, and clicking on the join group
link on the main website prompts you to confirm with the message "You
are now leaving Facebook." This link has been replaced with a direct
link to the group.